### PR TITLE
Optimization of Caching, Limit Enforcement, and Test Fixes in feature/cache-limits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,13 @@
       <version>5.15.2</version>
       <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.awaitility/awaitility -->
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.2.2</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
   <build>

--- a/src/main/java/com/weather/sdk/model/WeatherData.java
+++ b/src/main/java/com/weather/sdk/model/WeatherData.java
@@ -1,0 +1,51 @@
+package com.weather.sdk.model;
+
+public class WeatherData {
+    private final double temperature;
+    private final double feelsLike;
+    private final int visibility;
+    private final String description;
+    private final long datetime;
+    private final long sunrise;
+    private final long sunset;
+    private final int timezone;
+    private final String cityName;
+
+    public WeatherData(double temperature, double feelsLike, int visibility, String description,
+                       long datetime, long sunrise, long sunset, int timezone, String cityName) {
+        this.temperature = temperature;
+        this.feelsLike = feelsLike;
+        this.visibility = visibility;
+        this.description = description;
+        this.datetime = datetime;
+        this.sunrise = sunrise;
+        this.sunset = sunset;
+        this.timezone = timezone;
+        this.cityName = cityName;
+    }
+
+    public double getTemperature() { return temperature; }
+    public double getFeelsLike() { return feelsLike; }
+    public int getVisibility() { return visibility; }
+    public String getDescription() { return description; }
+    public long getDatetime() { return datetime; }
+    public long getSunrise() { return sunrise; }
+    public long getSunset() { return sunset; }
+    public int getTimezone() { return timezone; }
+    public String getCityName() { return cityName; }
+
+    @Override
+    public String toString() {
+        return "WeatherData{" +
+                "temperature=" + temperature +
+                ", feelsLike=" + feelsLike +
+                ", visibility=" + visibility +
+                ", description='" + description + '\'' +
+                ", datetime=" + datetime +
+                ", sunrise=" + sunrise +
+                ", sunset=" + sunset +
+                ", timezone=" + timezone +
+                ", cityName='" + cityName + '\'' +
+                '}';
+    }
+}

--- a/src/test/java/com/weather/sdk/BaseTest.java
+++ b/src/test/java/com/weather/sdk/BaseTest.java
@@ -2,6 +2,7 @@ package com.weather.sdk;
 
 import com.weather.sdk.enums.Mode;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,14 +15,21 @@ public abstract class BaseTest {
     @InjectMocks
     protected WeatherSDK weatherSDK;
 
+    @BeforeAll
+    static void beforeAll() {
+        WeatherSDK.clearInstances();
+    }
+
     @BeforeEach
     @DisplayName("Setup mock API key before each test")
     void setUp() {
+        WeatherSDK.clearInstances();
         weatherSDK = new WeatherSDK(Mode.ON_DEMAND);
     }
 
     @AfterEach
     void tearDown() {
         System.clearProperty("config.file");
+        WeatherSDK.clearInstances();
     }
 }

--- a/src/test/java/com/weather/sdk/BaseTest.java
+++ b/src/test/java/com/weather/sdk/BaseTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.TimeUnit;
 
 @ExtendWith(MockitoExtension.class)
 public abstract class BaseTest {
 
-    @InjectMocks
     protected WeatherSDK weatherSDK;
 
     @BeforeAll
@@ -24,7 +24,7 @@ public abstract class BaseTest {
     @DisplayName("Setup mock API key before each test")
     void setUp() {
         WeatherSDK.clearInstances();
-        weatherSDK = new WeatherSDK(Mode.ON_DEMAND);
+        weatherSDK = new WeatherSDK(Mode.ON_DEMAND, 2, TimeUnit.SECONDS);
     }
 
     @AfterEach

--- a/src/test/java/com/weather/sdk/WeatherSDKTest.java
+++ b/src/test/java/com/weather/sdk/WeatherSDKTest.java
@@ -65,4 +65,29 @@ class WeatherSDKTest extends BaseTest {
 
         Mockito.verify(spySDK, Mockito.times(1)).fetchWeather(city);
     }
+
+    @Test
+    @DisplayName("Should remove oldest city when more than 10 cities are added to cache")
+    void shouldRemoveOldestCityFromCache() throws IOException, InterruptedException {
+        WeatherSDK spySDK = Mockito.spy(new WeatherSDK(Mode.ON_DEMAND));
+
+        Mockito.doAnswer(invocation -> {
+            String city = invocation.getArgument(0);
+            return "weather for " + city;
+        }).when(spySDK).fetchWeather(Mockito.anyString());
+
+        // Add 11 cities to the cache
+        for (int i = 0; i < 11; i++) {
+            spySDK.getWeather("City" + i);
+        }
+
+        // When the 11th city is added, the oldest value (City0) should be removed
+        // Now, we request City0 again – if it was removed, fetchWeather will be called again
+        spySDK.getWeather("City0");
+
+        Mockito.verify(spySDK, Mockito.times(2)).fetchWeather("City0");
+
+        Mockito.verify(spySDK, Mockito.times(1)).fetchWeather("City10");
+    }
+
 }

--- a/src/test/java/com/weather/sdk/WeatherSDKTest.java
+++ b/src/test/java/com/weather/sdk/WeatherSDKTest.java
@@ -4,6 +4,7 @@ import com.weather.sdk.enums.Mode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
@@ -47,5 +48,21 @@ class WeatherSDKTest extends BaseTest {
         assertEquals("API key is required", exception.getMessage());
 
         System.clearProperty("config.file"); // Очистить после теста
+    }
+
+    @DisplayName("Should return cached weather data on second request")
+    @Test
+    void shouldReturnCachedWeatherData() throws Exception {
+        String city = "Berlin";
+        String expectedWeather = "{\"weather\":{\"main\":\"Clouds\",\"description\":\"scattered clouds\"}}";
+
+        WeatherSDK spySDK = Mockito.spy(new WeatherSDK(Mode.ON_DEMAND));
+
+        Mockito.doReturn(expectedWeather).when(spySDK).fetchWeather(city);
+
+        spySDK.getWeather(city); // Первый вызов (кэшируется)
+        spySDK.getWeather(city); // Второй вызов (должен брать из кэша)
+
+        Mockito.verify(spySDK, Mockito.times(1)).fetchWeather(city);
     }
 }

--- a/src/test/java/com/weather/sdk/WeatherSDKTest.java
+++ b/src/test/java/com/weather/sdk/WeatherSDKTest.java
@@ -73,7 +73,7 @@ class WeatherSDKTest extends BaseTest {
                 city  // cityName
         );
 
-        WeatherSDK spySDK = Mockito.spy(new WeatherSDK(Mode.ON_DEMAND));
+        WeatherSDK spySDK = Mockito.spy(weatherSDK);
 
         Mockito.doReturn(expectedWeather).when(spySDK).fetchWeather(city);
 
@@ -87,23 +87,24 @@ class WeatherSDKTest extends BaseTest {
     @Test
     @DisplayName("Should remove oldest city when more than 10 cities are added to cache")
     void shouldRemoveOldestCityFromCache() throws IOException, InterruptedException {
-        WeatherSDK spySDK = Mockito.spy(new WeatherSDK(Mode.ON_DEMAND));
+        WeatherSDK spySDK = Mockito.spy(weatherSDK);
 
         Mockito.doAnswer(invocation -> {
             String city = invocation.getArgument(0);
             return new WeatherData(
-                    25.0,  // temperature
-                    23.5,  // feelsLike
-                    10000, // visibility
+                    25.0,      // temperature
+                    23.5,      // feelsLike
+                    10000,     // visibility
                     "clear_sky", // description
                     1675744800L, // datetime
                     1675751262L, // sunrise
                     1675787560L, // sunset
-                    3600, // timezone
-                    city  // cityName
+                    3600,      // timezone
+                    city       // cityName
             );
         }).when(spySDK).fetchWeather(Mockito.anyString());
 
+        // Добавляем 11 городов в кэш
         for (int i = 0; i < 11; i++) {
             spySDK.getWeather("City" + i);
         }
@@ -112,6 +113,7 @@ class WeatherSDKTest extends BaseTest {
 
         Mockito.verify(spySDK, Mockito.times(2)).fetchWeather("City0");
     }
+
 
     @Test
     @DisplayName("Test JSON parsing and data structure")


### PR DESCRIPTION
**Description of Changes:**

- Cache limit enforcement: The SDK now stores a maximum of 10 cities, removing the oldest entry when adding an 11th city.
- Optimized caching in POLLING mode: Fixed issues in the weather data update logic.
- Updated unit tests in WeatherSDKTest to ensure proper validation of POLLING_MODE and cache limits.
- Fixed @InjectMocks issue in BaseTest by explicitly creating WeatherSDK with parameters.
- Adjusted data update intervals in tests to ensure faster polling execution.
- Added cache cleanup before each test to prevent interference from previous test runs.

**Improvements:**
-  Guaranteed removal of old data when cache size exceeds 10 cities.
-  Fully fixed POLLING_MODE logic, ensuring correct weather data updates.
-  Tests are now stable, eliminating flaky behavior.
-  Improved code readability and refactored tests for maintainability.
- 

**How to Test:**
1. Run WeatherSDKTest and ensure all tests pass.
2. Add an 11th city and verify that the oldest city is removed from the cache.
3. Confirm that polling correctly updates weather data at the expected interval.
4. Ensure no data leaks between test executions.